### PR TITLE
fix: upgrade django-simple-history 3.0.0 -> 3.7.0

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -67,7 +67,7 @@ django-filter==25.1
 django-model-utils==5.0.0
 django-redis==5.2.0
 django-ratelimit==4.1.0
-django-simple-history==3.0.0
+django-simple-history==3.7.0
 django-storages==1.14.2
 doc8==0.11.2
 docopt==0.6.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -242,7 +242,7 @@ django-ratelimit==4.1.0
     # via
    
     #   -r requirements-dev.in
-django-simple-history==3.0.0
+django-simple-history==3.7.0
     # via
    
     #   -r requirements-dev.in

--- a/requirements.in
+++ b/requirements.in
@@ -47,7 +47,7 @@ django-filter==25.1
 django-model-utils==5.0.0
 django-redis==5.2.0
 django-ratelimit==4.1.0
-django-simple-history==3.0.0
+django-simple-history==3.7.0
 django-storages==1.14.2
 django-webtest==1.9.13
 doc8==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -190,7 +190,7 @@ django-redis==5.2.0
     # via -r requirements.in
 django-ratelimit==4.1.0
     # via -r requirements.in
-django-simple-history==3.0.0
+django-simple-history==3.7.0
     # via -r requirements.in
 django-storages==1.14.2
     # via -r requirements.in


### PR DESCRIPTION
## Summary
- Upgrades `django-simple-history` from `3.0.0` to `3.7.0` to fix `pkg_resources` `ModuleNotFoundError` during `collectstatic` (build STEP 11/17)
- Version 3.0.0 imports `pkg_resources` at runtime, which was removed in `setuptools>=82`. Version 3.7.0 uses `pyproject.toml`/Hatchling instead, eliminating the dependency
- Updated all 4 requirement files (`requirements.in`, `requirements.txt`, `requirements-dev.in`, `requirements-dev.txt`)

## Compatibility
- 3.7.0 requires Django >= 4.2 (project uses 5.0.14) and Python >= 3.8 (project uses 3.12)
- No breaking API changes; project uses only basic `HistoricalRecords()` on 5 models + middleware

## Test plan
- [x] Full local test suite passes (1442 passed, 78 skipped)
- [x] CI pipeline passes (build STEP 11/17 `collectstatic` no longer fails)